### PR TITLE
fix: d'not setting zoom factor if the window is not mapped

### DIFF
--- a/src/widgets/qcef_web_view.cpp
+++ b/src/widgets/qcef_web_view.cpp
@@ -101,6 +101,7 @@ void QCefWebView::showEvent(QShowEvent* event) {
     QTimer::singleShot(1, this, [=]() {
       page()->remapBrowserWindow(this->winId());
     });
+    updateWebZoom();
   }
 }
 
@@ -129,10 +130,13 @@ bool QCefWebView::event(QEvent *event)
 
 void QCefWebView::updateWebZoom()
 {
+  if (!p_->window_mapped)
+    return;
+
   if (autoZoom())
     page()->setZoomFactor(devicePixelRatioF());
   else
-    page()->setZoomFactor(0);
+    page()->resetZoomFactor();
 }
 
 void QCefWebView::onScreenScaleChanged(QScreen *screen)


### PR DESCRIPTION
窗口未被map时不要设置其缩放比
修复网易云音乐在ubuntu上未开启屏幕缩放时登录界面显示不全