### PR TITLE
fix: crash on window close

### DIFF
--- a/src/core/qcef_client_handler.h
+++ b/src/core/qcef_client_handler.h
@@ -259,6 +259,7 @@ private:
     void NotifyFavicon(const CefString &icon_url, CefRefPtr<CefImage> icon);
 
     friend class QCefClientDownloadImageCallback;
+    friend class QCefWebPagePrivate;
 
     Delegate *delegate_ = nullptr;
 

--- a/src/widgets/qcef_web_page.cpp
+++ b/src/widgets/qcef_web_page.cpp
@@ -142,6 +142,7 @@ QCefWebPagePrivate::~QCefWebPagePrivate() {
     transport = nullptr;
   }
   if (client_handler != nullptr) {
+    client_handler->delegate_ = nullptr;
     client_handler = nullptr;
   }
 

--- a/src/widgets/qcef_web_view.cpp
+++ b/src/widgets/qcef_web_view.cpp
@@ -23,6 +23,8 @@
 #include <QTimer>
 #include <QWindow>
 
+#include <cmath>
+
 #include "widgets/qcef_web_page.h"
 
 struct QCefWebViewPrivate {
@@ -133,10 +135,13 @@ void QCefWebView::updateWebZoom()
   if (!p_->window_mapped)
     return;
 
-  if (autoZoom())
-    page()->setZoomFactor(devicePixelRatioF());
-  else
+  if (autoZoom()) {
+    // chromium 中缩放比例以 20% 递增，因此，zoomLevel 的值实际上表示递增的倍数
+    // 如，值为1时表示缩放为1.2倍，值为2时表示缩放为1.2*1.2倍
+    page()->setZoomFactor(std::log(devicePixelRatioF()) / std::log(1.2));
+  } else {
     page()->resetZoomFactor();
+  }
 }
 
 void QCefWebView::onScreenScaleChanged(QScreen *screen)


### PR DESCRIPTION
D'not set zoom level if the device pixel ratio is 1.0

修复关闭窗口时崩溃
窗口缩放比为1时不设置web页面的缩放